### PR TITLE
Removed superfluous 'babel-polyfill' import from App.jsx

### DIFF
--- a/client/App.jsx
+++ b/client/App.jsx
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import axios from 'axios';


### PR DESCRIPTION
To reduce the size of bundle.js, removed this unneeded import.